### PR TITLE
Fix BLE Lockup issue

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -228,6 +228,12 @@ public class DexCollectionService extends Service {
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 mConnectionState = STATE_DISCONNECTED;
                 ActiveBluetoothDevice.disconnected();
+                if(mBluetoothGatt != null) {
+                    Log.w(TAG, "onConnectionStateChange: mBluetoothGatt is not null, closing.");
+                    mBluetoothGatt.close();
+                    mBluetoothGatt = null;
+                    mCharacteristic = null;
+                }
                 lastdata = null;
                 Log.w(TAG, "onConnectionStateChange: Disconnected from GATT server.");
                 setRetryTimer();


### PR DESCRIPTION
Added code in onConnectionStateChange Bluetooth GATT Callback to correctly
close and null mBluetoothGatt when connection state changes to
DISCONNECTED.
Maybe the if(mBluetoothGatt != null) is overkill, but I believe it is best
to be safe rather than sorry.
